### PR TITLE
チーム数が多い場合に有効なIPアドレスでなくなる問題を解消

### DIFF
--- a/router/handlers.go
+++ b/router/handlers.go
@@ -240,7 +240,8 @@ func (h *Handlers) CreateInstance(c echo.Context) error {
 			Message: "起動中です"})
 	}
 
-	privateIP := fmt.Sprintf("192.168.0.%d", teamId*10+instanceNumber)
+	n := teamId*10 + instanceNumber
+	privateIP := fmt.Sprintf("192.168.%d.%d", n/255, n%255)
 	id, err := h.client.CreateInstance(name, privateIP, pass)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, model.Response{


### PR DESCRIPTION
26チーム以上参加した場合, IPアドレスの末尾8bitが255を超えます.